### PR TITLE
1.21.11 Port

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,20 +4,20 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.10
-yarn_mappings=1.21.10+build.3
-loader_version=0.18.2
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.4
+loader_version=0.18.4
 fabric_kotlin_version=1.13.7+kotlin.2.2.21
-loom_version=1.14-SNAPSHOT
+loom_version=1.15-SNAPSHOT
 
 # Dependencies
-yet_another_config_lib_version=3.6.1+1.21-fabric
-mod_menu_version=16.0.0-rc.1
+yet_another_config_lib_version=3.8.2+1.21.11-fabric
+mod_menu_version=17.0.0-beta.2
 
 # Mod Properties
-mod_version=1.2.0+mc1.21.10
+mod_version=1.2.0+mc1.21.11
 maven_group=openshock.integrations.minecraft
 archives_base_name=shockcraft
 
 # Dependencies
-fabric_version=0.138.3+1.21.10
+fabric_version=0.141.3+1.21.11

--- a/src/main/kotlin/openshock/integrations/minecraft/ConfigGuiFactory.kt
+++ b/src/main/kotlin/openshock/integrations/minecraft/ConfigGuiFactory.kt
@@ -1,14 +1,11 @@
 package openshock.integrations.minecraft
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory
-import dev.isxander.yacl3.api.ConfigCategory
-import dev.isxander.yacl3.api.ListOption
-import dev.isxander.yacl3.api.Option
-import dev.isxander.yacl3.api.OptionDescription
-import dev.isxander.yacl3.api.OptionGroup
-import dev.isxander.yacl3.api.YetAnotherConfigLib
-import dev.isxander.yacl3.api.controller.*
-import net.minecraft.client.MinecraftClient
+import dev.isxander.yacl3.api.*
+import dev.isxander.yacl3.api.controller.EnumControllerBuilder
+import dev.isxander.yacl3.api.controller.IntegerSliderControllerBuilder
+import dev.isxander.yacl3.api.controller.StringControllerBuilder
+import dev.isxander.yacl3.api.controller.TickBoxControllerBuilder
 import net.minecraft.client.gui.screen.Screen
 import net.minecraft.text.Text
 import openshock.integrations.minecraft.config.DamageShockMode

--- a/src/main/kotlin/openshock/integrations/minecraft/ShockCraft.kt
+++ b/src/main/kotlin/openshock/integrations/minecraft/ShockCraft.kt
@@ -1,36 +1,29 @@
 package openshock.integrations.minecraft
 
-import com.mojang.brigadier.CommandDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import net.fabricmc.api.ClientModInitializer
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents.EndTick
-import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback
 import net.minecraft.client.MinecraftClient
 import net.minecraft.client.gui.screen.GameMenuScreen
 import net.minecraft.client.network.ClientPlayerEntity
-import net.minecraft.command.CommandRegistryAccess
 import net.minecraft.entity.damage.DamageSource
-import net.minecraft.server.command.CommandManager
-import net.minecraft.server.command.CommandManager.literal
-import net.minecraft.server.command.ServerCommandSource
-import net.minecraft.text.Text
-import okhttp3.internal.wait
-import openshock.integrations.minecraft.config.DamageShockMode
-import openshock.integrations.minecraft.config.ShockCraftConfig
 import openshock.integrations.minecraft.api.ControlType
 import openshock.integrations.minecraft.api.OpenShockApi
+import openshock.integrations.minecraft.config.DamageShockMode
+import openshock.integrations.minecraft.config.ShockCraftConfig
 import openshock.integrations.minecraft.utils.MathUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.Calendar
+import java.util.*
 
-object ShockCraft : ModInitializer {
-    public val logger: Logger = LoggerFactory.getLogger("shockcraft")
+object ShockCraft : ClientModInitializer {
+    val logger: Logger = LoggerFactory.getLogger("shockcraft")
 
-    override fun onInitialize() {
+    override fun onInitializeClient() {
         logger.info("Hello Fabric world!")
 
         ShockCraftConfig.HANDLER.load()
@@ -41,6 +34,9 @@ object ShockCraft : ModInitializer {
     var lastTickHealth: Float = 20f
     var lastTickReset: Boolean = false
     var pauseMenuOpen: Boolean = true
+
+    val DamageSource?.attackerName: String
+        get() = this?.attacker?.stringifiedName ?: "Unknown"
 
     private fun reset() {
         lastTickReset = true
@@ -56,7 +52,7 @@ object ShockCraft : ModInitializer {
 
     @OptIn(DelicateCoroutinesApi::class)
     private fun clientTickLoopFun() {
-        val currentScreen = MinecraftClient.getInstance().currentScreen;
+        val currentScreen = MinecraftClient.getInstance().currentScreen
 
         // Cursed if logic to see if pause menu was opened, might not work with all mods
         if (currentScreen != null) {
@@ -126,7 +122,7 @@ object ShockCraft : ModInitializer {
             ControlType.Shock,
             config.onDeathIntensity,
             config.onDeathDuration,
-            getName(player.recentDamageSource)
+            player.recentDamageSource.attackerName,
         )
     }
 
@@ -177,16 +173,7 @@ object ShockCraft : ModInitializer {
             ControlType.Shock,
             intensity,
             duration,
-            getName(player.recentDamageSource)
+            player.recentDamageSource.attackerName,
         )
     }
-
-    private fun getName(damageSource: DamageSource?): String {
-        if (damageSource != null) {
-            return if (damageSource.attacker != null && damageSource.attacker!!.name.literalString != null) damageSource.attacker!!.name.literalString!!
-            else damageSource.name
-        }
-        return "Unknown"
-    }
-
 }

--- a/src/main/kotlin/openshock/integrations/minecraft/api/OpenShockApi.kt
+++ b/src/main/kotlin/openshock/integrations/minecraft/api/OpenShockApi.kt
@@ -9,10 +9,8 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
-import openshock.integrations.minecraft.ShockCraft
 import openshock.integrations.minecraft.config.ShockCraftConfig
 import openshock.integrations.minecraft.utils.await
-import org.w3c.dom.Text
 import org.slf4j.LoggerFactory
 
 


### PR DESCRIPTION
This pull requests port the version of the mod to 1.21.11. I have also fixed the mod entrypoint being incorrect.
In the `fabric.mod.json`, the entrypoint is for the client but in the code the entrypoint is for both client and server and it would prevent the game from launching. I also took the liberty to simplify the `getName` function to be more kotlin-ish as well as cleaning up the unused imports :3.

I have tested the mod locally with my openshock hub and it worked :+1: