### PR TITLE
Implement XP level up and chat message triggering

### DIFF
--- a/src/main/kotlin/openshock/integrations/minecraft/ConfigGuiFactory.kt
+++ b/src/main/kotlin/openshock/integrations/minecraft/ConfigGuiFactory.kt
@@ -180,6 +180,95 @@ object ConfigGuiFactory : ConfigScreenFactory<Screen> {
                         .build()
                     )
 
+                    .group(OptionGroup.createBuilder()
+                        .name(Text.literal("On Level Up"))
+                        .description(OptionDescription.of(Text.literal("Defines what happens when you gain an XP level")))
+
+                        .option(Option.createBuilder<Boolean>()
+                            .name(Text.literal("Enabled"))
+                            .description(OptionDescription.of(Text.literal("Enable shocking on level up")))
+                            .controller { TickBoxControllerBuilder.create(it) }
+                            .binding(defaults.onLevelUp, { config.onLevelUp }, { config.onLevelUp = it })
+                            .build()
+                        )
+                        .option(Option.createBuilder<Int>()
+                            .name(Text.literal("Intensity"))
+                            .controller { option ->
+                                IntegerSliderControllerBuilder.create(option)
+                                    .range(1, 100)
+                                    .step(1)
+                            }
+                            .binding(
+                                defaults.onLevelUpIntensity.toInt(),
+                                { config.onLevelUpIntensity.toInt() },
+                                { config.onLevelUpIntensity = it.toByte() })
+                            .build()
+                        )
+                        .option(Option.createBuilder<Int>()
+                            .name(Text.literal("Duration"))
+                            .controller { option ->
+                                IntegerSliderControllerBuilder.create(option)
+                                    .range(300, 30_000)
+                                    .step(100).formatValue { Text.literal((it / 1000f).toString() + " seconds") }
+                            }
+                            .binding(
+                                defaults.onLevelUpDuration.toInt(),
+                                { config.onLevelUpDuration.toInt() },
+                                { config.onLevelUpDuration = it.toUShort() })
+                            .build()
+                        )
+
+                        .build()
+                    )
+
+                    .group(OptionGroup.createBuilder()
+                        .name(Text.literal("On Chat Message"))
+                        .description(OptionDescription.of(Text.literal("Defines what happens when a specific chat phrase is sent or received")))
+
+                        .option(Option.createBuilder<Boolean>()
+                            .name(Text.literal("Enable for Chat Messages"))
+                            .description(OptionDescription.of(Text.literal("Enable shocking when a message with the key phrase is sent/received")))
+                            .controller { TickBoxControllerBuilder.create(it) }
+                            .binding(defaults.onChatEvent, { config.onChatEvent }, { config.onChatEvent = it })
+                            .build()
+                        )
+                        .option(Option.createBuilder<String>()
+                            .name(Text.literal("Key Phrase"))
+                            .description(OptionDescription.of(Text.literal("The phrase to trigger the shock")))
+                            .controller { StringControllerBuilder.create(it) }
+                            .binding(defaults.chatMessagePhrase, { config.chatMessagePhrase }, { config.chatMessagePhrase = it })
+                            .build()
+                        )
+                        .option(Option.createBuilder<Int>()
+                            .name(Text.literal("Intensity"))
+                            .controller { option ->
+                                IntegerSliderControllerBuilder.create(option)
+                                    .range(1, 100)
+                                    .step(1)
+                            }
+                            .binding(
+                                defaults.onChatMessageIntensity.toInt(),
+                                { config.onChatMessageIntensity.toInt() },
+                                { config.onChatMessageIntensity = it.toByte() })
+                            .build()
+                        )
+                        .option(Option.createBuilder<Int>()
+                            .name(Text.literal("Duration"))
+                            .controller { option ->
+                                IntegerSliderControllerBuilder.create(option)
+                                    .range(300, 30_000)
+                                    .step(100).formatValue { Text.literal((it / 1000f).toString() + " seconds") }
+                            }
+                            .binding(
+                                defaults.onChatMessageDuration.toInt(),
+                                { config.onChatMessageDuration.toInt() },
+                                { config.onChatMessageDuration = it.toUShort() })
+                            .build()
+                        )
+
+                        .build()
+                    )
+
                     .build()
             )
 

--- a/src/main/kotlin/openshock/integrations/minecraft/ShockCraft.kt
+++ b/src/main/kotlin/openshock/integrations/minecraft/ShockCraft.kt
@@ -4,9 +4,9 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import net.fabricmc.api.ClientModInitializer
-import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents.EndTick
+import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents
 import net.minecraft.client.MinecraftClient
 import net.minecraft.client.gui.screen.GameMenuScreen
 import net.minecraft.client.network.ClientPlayerEntity
@@ -29,11 +29,20 @@ object ShockCraft : ClientModInitializer {
         ShockCraftConfig.HANDLER.load()
 
         ClientTickEvents.END_CLIENT_TICK.register(EndTick { clientTickLoopFun() })
+
+        ClientReceiveMessageEvents.CHAT.register { message, _, _, _, _ ->
+            val config = ShockCraftConfig.HANDLER.instance()
+            if (config.onChatEvent) {
+                onChatMessage(message.string)
+            }
+        }
     }
 
     var lastTickHealth: Float = 20f
     var lastTickReset: Boolean = false
     var pauseMenuOpen: Boolean = true
+
+    var lastTickXpLevel: Int = 0
 
     val DamageSource?.attackerName: String
         get() = this?.attacker?.stringifiedName ?: "Unknown"
@@ -44,10 +53,12 @@ object ShockCraft : ClientModInitializer {
 
         if (player == null) {
             lastTickHealth = 20f
+            lastTickXpLevel = 0
             return
         }
 
         lastTickHealth = player.maxHealth
+        lastTickXpLevel = player.experienceLevel
     }
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -91,12 +102,15 @@ object ShockCraft : ClientModInitializer {
         if (lastTickReset) {
             lastTickReset = false
             lastTickHealth = player.health
+            lastTickXpLevel = player.experienceLevel
         }
 
         val damageSinceLastTick = (lastTickHealth - player.health).coerceAtLeast(0f)
+        val xpLevelChange = player.experienceLevel - lastTickXpLevel
 
-        // Set last tick health, we already calculated what we need
+        // Set last tick health and experience level, we already calculated what we need
         lastTickHealth = player.health
+        lastTickXpLevel = player.experienceLevel
 
         // Did we take damage?
         if (damageSinceLastTick > 0) {
@@ -111,6 +125,43 @@ object ShockCraft : ClientModInitializer {
             }
 
             GlobalScope.launch { onDamage(player, damageSinceLastTick) }
+        }
+
+        if (xpLevelChange > 0) {
+            logger.debug("Player leveled up by $xpLevelChange levels")
+            GlobalScope.launch {
+                onLevelUp(xpLevelChange)
+            }
+        }
+    }
+
+    private suspend fun onLevelUp(levels: Int) {
+        val config = ShockCraftConfig.HANDLER.instance()
+        if (!config.onLevelUp) return
+
+        OpenShockApi.control(
+            ControlType.Shock,
+            config.onLevelUpIntensity,
+            config.onLevelUpDuration,
+            "XP Level Up ($levels)",
+        )
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun onChatMessage(message: String) {
+        val config = ShockCraftConfig.HANDLER.instance()
+        if (config.chatMessagePhrase.isBlank()) return
+
+        if (message.contains(config.chatMessagePhrase, ignoreCase = true)) {
+            logger.debug("Chat message triggered shock: $message")
+            GlobalScope.launch {
+                OpenShockApi.control(
+                    ControlType.Shock,
+                    config.onChatMessageIntensity,
+                    config.onChatMessageDuration,
+                    "Chat Message Event",
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/openshock/integrations/minecraft/config/ShockCraftConfig.kt
+++ b/src/main/kotlin/openshock/integrations/minecraft/config/ShockCraftConfig.kt
@@ -62,6 +62,31 @@ class ShockCraftConfig {
 
     @SerialEntry
     var onDeathDuration: UShort = 2500u
+
+    // <--- On Level Up --->
+
+    @SerialEntry(comment = "Shock on level up?")
+    var onLevelUp: Boolean = false
+
+    @SerialEntry
+    var onLevelUpIntensity: Byte = 20
+
+    @SerialEntry
+    var onLevelUpDuration: UShort = 500u
+
+    // <--- On Chat Message --->
+
+    @SerialEntry(comment = "Shock when a specific phrase is sent/received in chat?")
+    var onChatEvent: Boolean = false
+
+    @SerialEntry(comment = "The phrase to trigger the shock")
+    var chatMessagePhrase: String = "shock me"
+
+    @SerialEntry
+    var onChatMessageIntensity: Byte = 30
+
+    @SerialEntry
+    var onChatMessageDuration: UShort = 1000u
     
     // <--- General --->
 


### PR DESCRIPTION
This PR implements two new additional configurable shock triggers, those being **XP Level Up** and **Chat Message Event**.

- **XP Level Up** simply does just as described: initiates a shock when the player gains an experience level.
- **Chat Message Event** allows the player to configure a "key phrase", that when is contained in a message received by the `ClientReceiveMessageEvents` listener (which receives both local and global chat events) will initiate a shock.

These changes have been tested locally and appear to work as intended.